### PR TITLE
Update to rustfft 6.0 and Rust 2018 edition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 **.DS_Store
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 
 [dependencies]
 apodize = "0.3.1"
-num = "0.2.0"
-rustfft = "3.0.1"
+num = "0.4.0"
+rustfft = "6.0.1"
 strider = "0.1.3"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.3.4"
 
 [[bench]]
 name = "lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "stft"
 readme = "README.md"
 repository = "https://github.com/snd/stft.git"
-version = "0.3.0"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
@@ -19,6 +19,7 @@ strider = "0.1.3"
 
 [dev-dependencies]
 criterion = "0.3.4"
+approx = "0.5.0"
 
 [[bench]]
 name = "lib"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,12 @@ version = "0.2.0"
 [dependencies]
 apodize = "0.3.1"
 num = "0.2.0"
-rustfft = "3.0.0"
+rustfft = "3.0.1"
 strider = "0.1.3"
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "lib"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "stft"
 readme = "README.md"
 repository = "https://github.com/snd/stft.git"
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 apodize = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "stft"
 readme = "README.md"
 repository = "https://github.com/snd/stft.git"
 version = "0.3.0"
+edition = "2018"
 
 [dependencies]
 apodize = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.3.0"
 edition = "2018"
 
 [dependencies]
-apodize = "0.3.1"
+apodize = "1.0.0"
 num = "0.4.0"
 rustfft = "6.0.1"
 strider = "0.1.3"

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,73 +1,73 @@
-#![feature(test)]
-extern crate test;
+extern crate criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 
 extern crate num;
 use num::complex::Complex;
 
 extern crate rustfft;
-use rustfft::FFT;
+use rustfft::FFTplanner;
 
 extern crate stft;
 use stft::{STFT, WindowType};
 
 macro_rules! bench_fft_process {
-    ($bencher:expr, $window_size:expr, $float:ty) => {{
+    ($c:expr, $window_size:expr, $float:ty) => {{
         let inverse = false;
-        let window_size = $window_size;
-        let mut fft = FFT::<$float>::new(window_size, inverse);
-        let input = std::iter::repeat(Complex::new(0., 0.))
-            .take(window_size)
+        let mut planner = FFTplanner::new(inverse);
+        let fft = planner.plan_fft($window_size);
+        let mut input = std::iter::repeat(Complex::new(0., 0.))
+            .take($window_size)
             .collect::<Vec<Complex<$float>>>();
         let mut output = std::iter::repeat(Complex::new(0., 0.))
-            .take(window_size)
+            .take($window_size)
             .collect::<Vec<Complex<$float>>>();
-        $bencher.iter(|| {
-            fft.process(&input[..], &mut output[..])
-        });
+        $c.bench_function(concat!("bench_fft_process_", stringify!($window_size), "_", stringify!($float)), |b| b.iter(|| {
+            fft.process(&mut input[..], &mut output[..])
+        }));
 
     }}
 }
 
-#[bench]
-fn bench_fft_process_1024_f32(bencher: &mut test::Bencher) {
-    bench_fft_process!(bencher, 1024, f32);
+fn bench_fft_process_1024_f32(c: &mut Criterion) {
+    bench_fft_process!(c, 1024, f32);
 }
 
-#[bench]
-fn bench_fft_process_1024_f64(bencher: &mut test::Bencher) {
-    bench_fft_process!(bencher, 1024, f64);
+fn bench_fft_process_1024_f64(c: &mut Criterion) {
+    bench_fft_process!(c, 1024, f64);
 }
+
+criterion_group!(benches_fft_process, bench_fft_process_1024_f32, bench_fft_process_1024_f64);
 
 macro_rules! bench_stft_compute {
-    ($bencher:expr, $window_size:expr, $float:ty) => {{
+    ($c:expr, $window_size:expr, $float:ty) => {{
         let mut stft = STFT::<$float>::new(WindowType::Hanning, $window_size, 0);
         let input = std::iter::repeat(1.).take($window_size).collect::<Vec<$float>>();
         let mut output = std::iter::repeat(0.).take(stft.output_size()).collect::<Vec<$float>>();
         stft.append_samples(&input[..]);
-        $bencher.iter(|| {
+        $c.bench_function(concat!("bench_stft_compute_", stringify!($window_size), "_", stringify!($float)), |b| b.iter(|| {
             stft.compute_column(&mut output[..])
-        });
+        }));
     }}
 }
 
-#[bench]
-fn bench_stft_compute_1024_f32(bencher: &mut test::Bencher) {
-    bench_stft_compute!(bencher, 1024, f32);
+fn bench_stft_compute_1024_f32(c: &mut Criterion) {
+    bench_stft_compute!(c, 1024, f32);
 }
 
-#[bench]
-fn bench_stft_compute_1024_f64(bencher: &mut test::Bencher) {
-    bench_stft_compute!(bencher, 1024, f64);
+fn bench_stft_compute_1024_f64(c: &mut Criterion) {
+    bench_stft_compute!(c, 1024, f64);
 }
+
+criterion_group!(benches_stft_compute, bench_stft_compute_1024_f32, bench_stft_compute_1024_f64);
 
 macro_rules! bench_stft_audio {
-    ($bencher:expr, $seconds:expr, $float:ty) => {{
+    ($c:expr, $seconds:expr, $float:ty) => {{
         // let's generate some fake audio
         let sample_rate: usize = 44100;
         let seconds: usize = $seconds;
         let sample_count = sample_rate * seconds;
         let all_samples = (0..sample_count).map(|x| x as $float).collect::<Vec<$float>>();
-        $bencher.iter(|| {
+        $c.bench_function(concat!("bench_stft_audio_", stringify!($windowsize), "_", stringify!($float)), |b| b.iter(|| {
             // let's initialize our short-time fourier transform
             let window_type: WindowType = WindowType::Hanning;
             let window_size: usize = 1024;
@@ -83,16 +83,18 @@ macro_rules! bench_stft_audio {
                     stft.move_to_next_column();
                 }
             }
-        });
+        }));
     }}
 }
 
-#[bench]
-fn bench_stft_10_seconds_audio_f32(bencher: &mut test::Bencher) {
-    bench_stft_audio!(bencher, 10, f32);
+fn bench_stft_10_seconds_audio_f32(c: &mut Criterion) {
+    bench_stft_audio!(c, 10, f32);
 }
 
-#[bench]
-fn bench_stft_10_seconds_audio_f64(bencher: &mut test::Bencher) {
-    bench_stft_audio!(bencher, 10, f64);
+fn bench_stft_10_seconds_audio_f64(c: &mut Criterion) {
+    bench_stft_audio!(c, 10, f64);
 }
+
+criterion_group!(benches_stft_audio, bench_stft_10_seconds_audio_f32, bench_stft_10_seconds_audio_f64);
+
+criterion_main!(benches_fft_process, benches_stft_compute, benches_stft_audio);

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,16 +1,13 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use num::complex::Complex;
-use rustfft::FFTplanner;
+use rustfft::{FftDirection, FftPlanner};
 use stft::{WindowType, STFT};
 
 macro_rules! bench_fft_process {
     ($c:expr, $window_size:expr, $float:ty) => {{
-        let inverse = false;
-        let mut planner = FFTplanner::new(inverse);
-        let fft = planner.plan_fft($window_size);
-        let mut input = std::iter::repeat(Complex::new(0., 0.))
-            .take($window_size)
-            .collect::<Vec<Complex<$float>>>();
+        let mut planner = FftPlanner::new();
+        let fft = planner.plan_fft($window_size, FftDirection::Forward);
+        // input is processed in-place
         let mut output = std::iter::repeat(Complex::new(0., 0.))
             .take($window_size)
             .collect::<Vec<Complex<$float>>>();
@@ -21,7 +18,7 @@ macro_rules! bench_fft_process {
                 "_",
                 stringify!($float)
             ),
-            |b| b.iter(|| fft.process(&mut input[..], &mut output[..])),
+            |b| b.iter(|| fft.process(&mut output[..])),
         );
     }};
 }

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -42,7 +42,8 @@ criterion_group!(
 
 macro_rules! bench_stft_compute {
     ($c:expr, $window_size:expr, $float:ty) => {{
-        let mut stft = STFT::<$float>::new(WindowType::Hanning, $window_size, 0);
+        let step_size: usize = 512;
+        let mut stft = STFT::<$float>::new(WindowType::Hanning, $window_size, step_size);
         let input = std::iter::repeat(1.)
             .take($window_size)
             .collect::<Vec<$float>>();

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -1,14 +1,7 @@
-extern crate criterion;
 use criterion::{criterion_group, criterion_main, Criterion};
-
-extern crate num;
 use num::complex::Complex;
-
-extern crate rustfft;
 use rustfft::FFTplanner;
-
-extern crate stft;
-use stft::{STFT, WindowType};
+use stft::{WindowType, STFT};
 
 macro_rules! bench_fft_process {
     ($c:expr, $window_size:expr, $float:ty) => {{
@@ -21,11 +14,16 @@ macro_rules! bench_fft_process {
         let mut output = std::iter::repeat(Complex::new(0., 0.))
             .take($window_size)
             .collect::<Vec<Complex<$float>>>();
-        $c.bench_function(concat!("bench_fft_process_", stringify!($window_size), "_", stringify!($float)), |b| b.iter(|| {
-            fft.process(&mut input[..], &mut output[..])
-        }));
-
-    }}
+        $c.bench_function(
+            concat!(
+                "bench_fft_process_",
+                stringify!($window_size),
+                "_",
+                stringify!($float)
+            ),
+            |b| b.iter(|| fft.process(&mut input[..], &mut output[..])),
+        );
+    }};
 }
 
 fn bench_fft_process_1024_f32(c: &mut Criterion) {
@@ -36,18 +34,32 @@ fn bench_fft_process_1024_f64(c: &mut Criterion) {
     bench_fft_process!(c, 1024, f64);
 }
 
-criterion_group!(benches_fft_process, bench_fft_process_1024_f32, bench_fft_process_1024_f64);
+criterion_group!(
+    benches_fft_process,
+    bench_fft_process_1024_f32,
+    bench_fft_process_1024_f64
+);
 
 macro_rules! bench_stft_compute {
     ($c:expr, $window_size:expr, $float:ty) => {{
         let mut stft = STFT::<$float>::new(WindowType::Hanning, $window_size, 0);
-        let input = std::iter::repeat(1.).take($window_size).collect::<Vec<$float>>();
-        let mut output = std::iter::repeat(0.).take(stft.output_size()).collect::<Vec<$float>>();
+        let input = std::iter::repeat(1.)
+            .take($window_size)
+            .collect::<Vec<$float>>();
+        let mut output = std::iter::repeat(0.)
+            .take(stft.output_size())
+            .collect::<Vec<$float>>();
         stft.append_samples(&input[..]);
-        $c.bench_function(concat!("bench_stft_compute_", stringify!($window_size), "_", stringify!($float)), |b| b.iter(|| {
-            stft.compute_column(&mut output[..])
-        }));
-    }}
+        $c.bench_function(
+            concat!(
+                "bench_stft_compute_",
+                stringify!($window_size),
+                "_",
+                stringify!($float)
+            ),
+            |b| b.iter(|| stft.compute_column(&mut output[..])),
+        );
+    }};
 }
 
 fn bench_stft_compute_1024_f32(c: &mut Criterion) {
@@ -58,7 +70,11 @@ fn bench_stft_compute_1024_f64(c: &mut Criterion) {
     bench_stft_compute!(c, 1024, f64);
 }
 
-criterion_group!(benches_stft_compute, bench_stft_compute_1024_f32, bench_stft_compute_1024_f64);
+criterion_group!(
+    benches_stft_compute,
+    bench_stft_compute_1024_f32,
+    bench_stft_compute_1024_f64
+);
 
 macro_rules! bench_stft_audio {
     ($c:expr, $seconds:expr, $float:ty) => {{
@@ -66,25 +82,37 @@ macro_rules! bench_stft_audio {
         let sample_rate: usize = 44100;
         let seconds: usize = $seconds;
         let sample_count = sample_rate * seconds;
-        let all_samples = (0..sample_count).map(|x| x as $float).collect::<Vec<$float>>();
-        $c.bench_function(concat!("bench_stft_audio_", stringify!($windowsize), "_", stringify!($float)), |b| b.iter(|| {
-            // let's initialize our short-time fourier transform
-            let window_type: WindowType = WindowType::Hanning;
-            let window_size: usize = 1024;
-            let step_size: usize = 512;
-            let mut stft = STFT::<$float>::new(window_type, window_size, step_size);
-            // we need a buffer to hold a computed column of the spectrogram
-            let mut spectrogram_column: Vec<$float> =
-                std::iter::repeat(0.).take(stft.output_size()).collect();
-            for some_samples in (&all_samples[..]).chunks(3000) {
-                stft.append_samples(some_samples);
-                while stft.contains_enough_to_compute() {
-                    stft.compute_column(&mut spectrogram_column[..]);
-                    stft.move_to_next_column();
-                }
-            }
-        }));
-    }}
+        let all_samples = (0..sample_count)
+            .map(|x| x as $float)
+            .collect::<Vec<$float>>();
+        $c.bench_function(
+            concat!(
+                "bench_stft_audio_",
+                stringify!($windowsize),
+                "_",
+                stringify!($float)
+            ),
+            |b| {
+                b.iter(|| {
+                    // let's initialize our short-time fourier transform
+                    let window_type: WindowType = WindowType::Hanning;
+                    let window_size: usize = 1024;
+                    let step_size: usize = 512;
+                    let mut stft = STFT::<$float>::new(window_type, window_size, step_size);
+                    // we need a buffer to hold a computed column of the spectrogram
+                    let mut spectrogram_column: Vec<$float> =
+                        std::iter::repeat(0.).take(stft.output_size()).collect();
+                    for some_samples in (&all_samples[..]).chunks(3000) {
+                        stft.append_samples(some_samples);
+                        while stft.contains_enough_to_compute() {
+                            stft.compute_column(&mut spectrogram_column[..]);
+                            stft.move_to_next_column();
+                        }
+                    }
+                })
+            },
+        );
+    }};
 }
 
 fn bench_stft_10_seconds_audio_f32(c: &mut Criterion) {
@@ -95,6 +123,14 @@ fn bench_stft_10_seconds_audio_f64(c: &mut Criterion) {
     bench_stft_audio!(c, 10, f64);
 }
 
-criterion_group!(benches_stft_audio, bench_stft_10_seconds_audio_f32, bench_stft_10_seconds_audio_f64);
+criterion_group!(
+    benches_stft_audio,
+    bench_stft_10_seconds_audio_f32,
+    bench_stft_10_seconds_audio_f64
+);
 
-criterion_main!(benches_fft_process, benches_stft_compute, benches_stft_audio);
+criterion_main!(
+    benches_fft_process,
+    benches_stft_compute,
+    benches_stft_audio
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ where
 
     #[inline]
     pub fn output_size(&self) -> usize {
-        self.window_size / 2
+        self.fft_size / 2
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub struct STFT<T>
 {
     pub window_size: usize,
     pub step_size: usize,
-    pub fft: Arc<FFT<T>>,
+    pub fft: Arc<dyn FFT<T>>,
     pub window: Option<Vec<T>>,
     /// internal ringbuffer used to store samples
     pub sample_ring: SliceRingImpl<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,6 +249,11 @@ where
         self.sample_ring.len()
     }
 
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub fn append_samples(&mut self, input: &[T]) {
         self.sample_ring.push_many_back(input);
     }
@@ -274,7 +279,7 @@ where
         // copy windowed real_input as real parts into complex_input
         // only copy `window_size` size, leave the rest in `complex_input` be zero
         for (src, dst) in self.real_input.iter().zip(self.complex_input.iter_mut()) {
-            dst.re = src.clone();
+            dst.re = *src;
         }
 
         // compute fft
@@ -290,7 +295,7 @@ where
         self.compute_into_complex_output();
 
         for (dst, src) in output.iter_mut().zip(self.complex_output.iter()) {
-            *dst = src.clone();
+            *dst = *src;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,48 +11,46 @@ to the `[dependencies]` section of your `Cargo.toml` and call `extern crate stft
 ```
 use stft::{STFT, WindowType};
 
-fn main() {
-    // let's generate ten seconds of fake audio
-    let sample_rate: usize = 44100;
-    let seconds: usize = 10;
-    let sample_count = sample_rate * seconds;
-    let all_samples = (0..sample_count).map(|x| x as f64).collect::<Vec<f64>>();
+// let's generate ten seconds of fake audio
+let sample_rate: usize = 44100;
+let seconds: usize = 10;
+let sample_count = sample_rate * seconds;
+let all_samples = (0..sample_count).map(|x| x as f64).collect::<Vec<f64>>();
 
-    // let's initialize our short-time fourier transform
-    let window_type: WindowType = WindowType::Hanning;
-    let window_size: usize = 1024;
-    let step_size: usize = 512;
-    let mut stft = STFT::new(window_type, window_size, step_size);
+// let's initialize our short-time fourier transform
+let window_type: WindowType = WindowType::Hanning;
+let window_size: usize = 1024;
+let step_size: usize = 512;
+let mut stft = STFT::new(window_type, window_size, step_size);
 
-    // we need a buffer to hold a computed column of the spectrogram
-    let mut spectrogram_column: Vec<f64> =
-        std::iter::repeat(0.).take(stft.output_size()).collect();
+// we need a buffer to hold a computed column of the spectrogram
+let mut spectrogram_column: Vec<f64> =
+    std::iter::repeat(0.).take(stft.output_size()).collect();
 
-    // iterate over all the samples in chunks of 3000 samples.
-    // in a real program you would probably read from something instead.
-    for some_samples in (&all_samples[..]).chunks(3000) {
-        // append the samples to the internal ringbuffer of the stft
-        stft.append_samples(some_samples);
+// iterate over all the samples in chunks of 3000 samples.
+// in a real program you would probably read from something instead.
+for some_samples in (&all_samples[..]).chunks(3000) {
+    // append the samples to the internal ringbuffer of the stft
+    stft.append_samples(some_samples);
 
-        // as long as there remain window_size samples in the internal
-        // ringbuffer of the stft
-        while stft.contains_enough_to_compute() {
-            // compute one column of the stft by
-            // taking the first window_size samples of the internal ringbuffer,
-            // multiplying them with the window,
-            // computing the fast fourier transform,
-            // taking half of the symetric complex outputs,
-            // computing the norm of the complex outputs and
-            // taking the log10
-            stft.compute_column(&mut spectrogram_column[..]);
+    // as long as there remain window_size samples in the internal
+    // ringbuffer of the stft
+    while stft.contains_enough_to_compute() {
+        // compute one column of the stft by
+        // taking the first window_size samples of the internal ringbuffer,
+        // multiplying them with the window,
+        // computing the fast fourier transform,
+        // taking half of the symetric complex outputs,
+        // computing the norm of the complex outputs and
+        // taking the log10
+        stft.compute_column(&mut spectrogram_column[..]);
 
-            // here's where you would do something with the
-            // spectrogram_column...
+        // here's where you would do something with the
+        // spectrogram_column...
 
-            // drop step_size samples from the internal ringbuffer of the stft
-            // making a step of size step_size
-            stft.move_to_next_column();
-        }
+        // drop step_size samples from the internal ringbuffer of the stft
+        // making a step of size step_size
+        stft.move_to_next_column();
     }
 }
 ```

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,14 +1,21 @@
 use std::str::FromStr;
-
-extern crate stft;
-use stft::{STFT, WindowType};
+use stft::{WindowType, STFT};
 
 #[test]
 fn test_window_type_from_string() {
-    assert_eq!(WindowType::from_str("Hanning").unwrap(), WindowType::Hanning);
-    assert_eq!(WindowType::from_str("hanning").unwrap(), WindowType::Hanning);
+    assert_eq!(
+        WindowType::from_str("Hanning").unwrap(),
+        WindowType::Hanning
+    );
+    assert_eq!(
+        WindowType::from_str("hanning").unwrap(),
+        WindowType::Hanning
+    );
     assert_eq!(WindowType::from_str("hann").unwrap(), WindowType::Hanning);
-    assert_eq!(WindowType::from_str("blackman").unwrap(), WindowType::Blackman);
+    assert_eq!(
+        WindowType::from_str("blackman").unwrap(),
+        WindowType::Blackman
+    );
 }
 
 #[test]
@@ -20,7 +27,11 @@ fn test_window_type_to_string() {
 fn test_window_types_to_strings() {
     assert_eq!(
         vec!["Hanning", "Hamming", "Blackman", "Nuttall", "None"],
-        WindowType::values().iter().map(|x| x.to_string()).collect::<Vec<String>>());
+        WindowType::values()
+            .iter()
+            .map(|x| x.to_string())
+            .collect::<Vec<String>>()
+    );
 }
 
 #[test]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,3 +1,4 @@
+use approx::assert_ulps_eq;
 use std::str::FromStr;
 use stft::{WindowType, STFT};
 
@@ -63,6 +64,19 @@ fn test_stft() {
     let mut output: Vec<f64> = vec![0.; 4];
     stft.compute_column(&mut output);
     println!("{:?}", output);
+
+    let expected = vec![
+        2.7763337740785166,
+        2.7149781042402594,
+        2.6218024907053796,
+        2.647816050270838,
+    ];
+    assert_ulps_eq!(output.as_slice(), expected.as_slice(), max_ulps = 10);
+
+    // repeat the calculation to ensure results are independent of the internal buffer
+    let mut output2: Vec<f64> = vec![0.; 4];
+    stft.compute_column(&mut output2);
+    assert_ulps_eq!(output.as_slice(), output2.as_slice(), max_ulps = 10);
 }
 
 #[test]
@@ -84,4 +98,29 @@ fn test_stft_padded() {
     let mut output: Vec<f64> = vec![0.; 16];
     stft.compute_column(&mut output);
     println!("{:?}", output);
+
+    let expected = vec![
+        2.7763337740785166,
+        2.772158781619449,
+        2.7598791705720664,
+        2.740299218211912,
+        2.7149781042402594,
+        2.686495897766628,
+        2.6585877421915676,
+        2.635728083951981,
+        2.6218024907053796,
+        2.6183544930578027,
+        2.6238833073831658,
+        2.634925941918913,
+        2.647816050270838,
+        2.65977332745612,
+        2.6691025866822033,
+        2.6749381613735683,
+    ];
+    assert_ulps_eq!(output.as_slice(), expected.as_slice(), max_ulps = 10);
+
+    // repeat the calculation to ensure results are independent of the internal buffer
+    let mut output2: Vec<f64> = vec![0.; 16];
+    stft.compute_column(&mut output2);
+    assert_ulps_eq!(output.as_slice(), output2.as_slice(), max_ulps = 10);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -50,18 +50,18 @@ fn test_stft() {
     assert!(!stft.contains_enough_to_compute());
     assert_eq!(stft.output_size(), 4);
     assert_eq!(stft.len(), 0);
-    stft.append_samples(&vec![500., 0., 100.][..]);
+    stft.append_samples(&[500., 0., 100.]);
     assert_eq!(stft.len(), 3);
     assert!(!stft.contains_enough_to_compute());
-    stft.append_samples(&vec![500., 0., 100., 0.][..]);
+    stft.append_samples(&[500., 0., 100., 0.]);
     assert_eq!(stft.len(), 7);
     assert!(!stft.contains_enough_to_compute());
 
-    stft.append_samples(&vec![500.][..]);
+    stft.append_samples(&[500.]);
     assert!(stft.contains_enough_to_compute());
 
     let mut output: Vec<f64> = vec![0.; 4];
-    stft.compute_column(&mut output[..]);
+    stft.compute_column(&mut output);
     println!("{:?}", output);
 }
 
@@ -71,17 +71,17 @@ fn test_stft_padded() {
     assert!(!stft.contains_enough_to_compute());
     assert_eq!(stft.output_size(), 16);
     assert_eq!(stft.len(), 0);
-    stft.append_samples(&vec![500., 0., 100.][..]);
+    stft.append_samples(&[500., 0., 100.]);
     assert_eq!(stft.len(), 3);
     assert!(!stft.contains_enough_to_compute());
-    stft.append_samples(&vec![500., 0., 100., 0.][..]);
+    stft.append_samples(&[500., 0., 100., 0.]);
     assert_eq!(stft.len(), 7);
     assert!(!stft.contains_enough_to_compute());
 
-    stft.append_samples(&vec![500.][..]);
+    stft.append_samples(&[500.]);
     assert!(stft.contains_enough_to_compute());
 
     let mut output: Vec<f64> = vec![0.; 16];
-    stft.compute_column(&mut output[..]);
+    stft.compute_column(&mut output);
     println!("{:?}", output);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -64,3 +64,24 @@ fn test_stft() {
     stft.compute_column(&mut output[..]);
     println!("{:?}", output);
 }
+
+#[test]
+fn test_stft_padded() {
+    let mut stft = STFT::new_with_zero_padding(WindowType::Hanning, 8, 32, 4);
+    assert!(!stft.contains_enough_to_compute());
+    assert_eq!(stft.output_size(), 16);
+    assert_eq!(stft.len(), 0);
+    stft.append_samples(&vec![500., 0., 100.][..]);
+    assert_eq!(stft.len(), 3);
+    assert!(!stft.contains_enough_to_compute());
+    stft.append_samples(&vec![500., 0., 100., 0.][..]);
+    assert_eq!(stft.len(), 7);
+    assert!(!stft.contains_enough_to_compute());
+
+    stft.append_samples(&vec![500.][..]);
+    assert!(stft.contains_enough_to_compute());
+
+    let mut output: Vec<f64> = vec![0.; 16];
+    stft.compute_column(&mut output[..]);
+    println!("{:?}", output);
+}


### PR DESCRIPTION
Heya! When I tried to use stft from crates.io it failed with an error related to `nalgebra-0.5`. I poked around in the forks and found [YoshieraHuang/stft](https://github.com/YoshieraHuang/stft) which adds some modernizations on which this PR is based:

- Zero-padding FFT through `STFT::new_with_zero_padding()` (via https://github.com/YoshieraHuang/stft/commit/3695eb86ebd7e7c7cd5949faf939c52d25fbd7d7)
- More importantly, an update of the test/bench suite to Criterion (via https://github.com/YoshieraHuang/stft/commit/bad50ff5e200aab957ea1ddfa11f9e2ced41bff4).

The latter commit allows `cargo bench` and `cargo criterion` to be run with stable Rust.

From there, I updated the `Cargo.toml` to use `edition = "2018"` and updated the dependencies to `rustfft = "6.0"`, `num = "0.4"` and `apodize = "1.0"`. I made sure to sanitize the code using rustfmt and Clippy.

The newer rustfft version appears to do FFT in-place now, but has support for an externally allocated scratch buffer. I added this to the `STFT` struct - the benchmarks indicate a slight performance increase with that change.

The existing integration tests were lacking an assertion to actually ensure the correct results are calculated. I added a dev dependency on `approx = "0.5"` to do perform said comparisons; the calculations are now also performed twice to ensure that a call to `compute_column()` does not
corrupt the internal state.